### PR TITLE
Session/10

### DIFF
--- a/test/error_listener_test.dart
+++ b/test/error_listener_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_training/main.dart';
+import 'package:flutter_training/ui/providers/weather_state_notifier_provider.dart';
+import 'package:yumemi_weather/yumemi_weather.dart';
+
+import 'mock/mock_weather_state_notifier.dart';
+
+Future<void> _pumpMainAppWithErrorNotifier(
+  WidgetTester tester, {
+  required YumemiWeatherError error,
+}) async {
+  final container = ProviderContainer(
+    overrides: [
+      weatherStateNotifierProvider.overrideWith(
+        () => MockWeatherStateNotifier(error: error),
+      ),
+    ],
+  );
+
+  // 適切な画面サイズを設定してレイアウトオーバーフローを防ぐ
+  tester.view.physicalSize = const Size(1200, 2400);
+  tester.view.devicePixelRatio = 1.0;
+
+  addTearDown(() {
+    container.dispose();
+    tester.view.reset();
+  });
+
+  // MainAppを起動
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MainApp(),
+    ),
+  );
+
+  // GreenWidgetから500ms後にWeatherScreenに自動遷移するのを待つ
+  await tester.pumpAndSettle(const Duration(milliseconds: 500));
+}
+
+void main() {
+  testWidgets('無効なパラメーターエラーダイアログが表示されること', (tester) async {
+    await _pumpMainAppWithErrorNotifier(
+      tester,
+      error: YumemiWeatherError.invalidParameter,
+    );
+
+    // Reloadボタンをタップ
+    await tester.tap(find.text('Reload'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.text('天気の取得に失敗しました。'), findsOneWidget);
+    expect(find.text('無効なパラメーターが指定されました。'), findsOneWidget);
+    expect(find.text('OK'), findsOneWidget);
+
+    // OKボタンをタップ
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('不明なエラーダイアログが表示されること', (tester) async {
+    await _pumpMainAppWithErrorNotifier(
+      tester,
+      error: YumemiWeatherError.unknown,
+    );
+
+    // Reloadボタンをタップ
+    await tester.tap(find.text('Reload'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.text('天気の取得に失敗しました。'), findsOneWidget);
+    expect(find.text('不明なエラーが発生しました。'), findsOneWidget);
+    expect(find.text('OK'), findsOneWidget);
+
+    // OKボタンをタップ
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+}

--- a/test/extension/weather_condition_test_extension.dart
+++ b/test/extension/weather_condition_test_extension.dart
@@ -1,9 +1,0 @@
-import 'package:flutter_svg/flutter_svg.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_training/core/entity/weather_condition.dart';
-
-extension WeatherConditionTestExtension on WeatherCondition {
-  Finder get finder => find.byWidgetPredicate(
-    (widget) => widget is SvgPicture && widget.semanticsLabel == name,
-  );
-}

--- a/test/extension/weather_condition_test_extension.dart
+++ b/test/extension/weather_condition_test_extension.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_training/core/entity/weather_condition.dart';
+
+extension WeatherConditionTestExtension on WeatherCondition {
+  Finder get finder => find.byWidgetPredicate(
+    (widget) => widget is SvgPicture && widget.semanticsLabel == name,
+  );
+}

--- a/test/mock/mock_weather_state_notifier.dart
+++ b/test/mock/mock_weather_state_notifier.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_training/core/entity/weather.dart';
+import 'package:flutter_training/core/entity/weather_condition.dart';
+import 'package:flutter_training/ui/notifiers/weather_state_notifier.dart';
+import 'package:yumemi_weather/yumemi_weather.dart';
+
+class MockWeatherStateNotifier extends WeatherStateNotifier {
+  MockWeatherStateNotifier({
+    this.shouldFail = false,
+    this.weatherCondition = WeatherCondition.sunny,
+  });
+
+  final bool shouldFail;
+  final WeatherCondition weatherCondition;
+
+  @override
+  WeatherState build() => const WeatherState();
+
+  @override
+  void updateWeather({required String area, required DateTime date}) {
+    if (shouldFail) {
+      state = const WeatherState(error: YumemiWeatherError.invalidParameter);
+    } else {
+      state = WeatherState(
+        weather: Weather(
+          weatherCondition: weatherCondition,
+          maxTemperature: 30,
+          minTemperature: 20,
+          date: DateTime.parse('2024-01-01T00:00:00Z'),
+        ),
+      );
+    }
+  }
+}

--- a/test/mock/mock_weather_state_notifier.dart
+++ b/test/mock/mock_weather_state_notifier.dart
@@ -1,33 +1,25 @@
 import 'package:flutter_training/core/entity/weather.dart';
-import 'package:flutter_training/core/entity/weather_condition.dart';
 import 'package:flutter_training/ui/notifiers/weather_state_notifier.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
 
 class MockWeatherStateNotifier extends WeatherStateNotifier {
   MockWeatherStateNotifier({
-    this.shouldFail = false,
-    this.weatherCondition = WeatherCondition.sunny,
+    this.error,
+    this.weather,
   });
 
-  final bool shouldFail;
-  final WeatherCondition weatherCondition;
+  final YumemiWeatherError? error;
+  final Weather? weather;
 
   @override
   WeatherState build() => const WeatherState();
 
   @override
   void updateWeather({required String area, required DateTime date}) {
-    if (shouldFail) {
-      state = const WeatherState(error: YumemiWeatherError.invalidParameter);
-    } else {
-      state = WeatherState(
-        weather: Weather(
-          weatherCondition: weatherCondition,
-          maxTemperature: 30,
-          minTemperature: 20,
-          date: DateTime.parse('2024-01-01T00:00:00Z'),
-        ),
-      );
+    if (error != null) {
+      state = WeatherState(error: error);
+    } else if (weather != null) {
+      state = WeatherState(weather: weather);
     }
   }
 }

--- a/test/weather_screen_test.dart
+++ b/test/weather_screen_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_training/core/entity/weather_condition.dart';
+import 'package:flutter_training/main.dart';
+import 'package:flutter_training/ui/providers/weather_state_notifier_provider.dart';
+
+import 'mock/mock_weather_state_notifier.dart';
+
+Future<ProviderContainer> _pumpMainAppWithMockNotifier(
+  WidgetTester tester, {
+  bool shouldFail = false,
+  WeatherCondition weatherCondition = WeatherCondition.sunny,
+}) async {
+  final container = ProviderContainer(
+    overrides: [
+      weatherStateNotifierProvider.overrideWith(
+        () => MockWeatherStateNotifier(
+          shouldFail: shouldFail,
+          weatherCondition: weatherCondition,
+        ),
+      ),
+    ],
+  );
+
+  tester.view.physicalSize = const Size(1200, 2400);
+  tester.view.devicePixelRatio = 1.0;
+
+  // MainAppを起動
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MainApp(),
+    ),
+  );
+
+  // GreenWidgetから500ms後にWeatherScreenに自動遷移するのを待つ
+  await tester.pumpAndSettle(const Duration(seconds: 1));
+
+  return container;
+}
+
+void main() {
+  testWidgets('晴れの画像が表示されること', (tester) async {
+    await _pumpMainAppWithMockNotifier(tester);
+    expect(find.byType(SvgPicture), findsNothing);
+
+    await tester.tap(find.text('Reload'));
+    await tester.pumpAndSettle();
+    expect(
+      find.byWidgetPredicate(
+        (widget) => widget is SvgPicture && widget.semanticsLabel == 'sunny',
+      ),
+      findsOneWidget,
+    );
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('曇りの画像が表示されること', (tester) async {
+    await _pumpMainAppWithMockNotifier(
+      tester,
+      weatherCondition: WeatherCondition.cloudy,
+    );
+    expect(find.byType(SvgPicture), findsNothing);
+
+    await tester.tap(find.text('Reload'));
+    await tester.pumpAndSettle();
+    expect(
+      find.byWidgetPredicate(
+        (widget) => widget is SvgPicture && widget.semanticsLabel == 'cloudy',
+      ),
+      findsOneWidget,
+    );
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('雨の画像が表示されること', (tester) async {
+    await _pumpMainAppWithMockNotifier(
+      tester,
+      weatherCondition: WeatherCondition.rainy,
+    );
+    expect(find.byType(SvgPicture), findsNothing);
+
+    await tester.tap(find.text('Reload'));
+    await tester.pumpAndSettle();
+    expect(
+      find.byWidgetPredicate(
+        (widget) => widget is SvgPicture && widget.semanticsLabel == 'rainy',
+      ),
+      findsOneWidget,
+    );
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('最高気温が表示されること', (tester) async {
+    await _pumpMainAppWithMockNotifier(tester);
+    await tester.tap(find.text('Reload'));
+    await tester.pumpAndSettle();
+    final maxTempFinder = find.byWidgetPredicate(
+      (widget) =>
+          widget is Text &&
+          widget.data == '30 ℃' &&
+          widget.style?.color == Colors.red,
+    );
+    expect(maxTempFinder, findsOneWidget);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('最低気温が表示されること', (tester) async {
+    await _pumpMainAppWithMockNotifier(tester);
+    await tester.tap(find.text('Reload'));
+    await tester.pumpAndSettle();
+    final minTempFinder = find.byWidgetPredicate(
+      (widget) =>
+          widget is Text &&
+          widget.data == '20 ℃' &&
+          widget.style?.color == Colors.blue,
+    );
+    expect(minTempFinder, findsOneWidget);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('エラーダイアログが表示されること', (tester) async {
+    await _pumpMainAppWithMockNotifier(tester, shouldFail: true);
+    await tester.tap(find.text('Reload'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.text('天気の取得に失敗しました。'), findsOneWidget);
+    expect(find.text('無効なパラメーターが指定されました。'), findsOneWidget);
+    expect(find.text('OK'), findsOneWidget);
+
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+}

--- a/test/weather_screen_test.dart
+++ b/test/weather_screen_test.dart
@@ -36,7 +36,7 @@ Future<ProviderContainer> _pumpMainAppWithMockNotifier(
   );
 
   // GreenWidgetから500ms後にWeatherScreenに自動遷移するのを待つ
-  await tester.pumpAndSettle(const Duration(seconds: 1));
+  await tester.pumpAndSettle(const Duration(milliseconds: 500));
 
   return container;
 }

--- a/test/weather_screen_test.dart
+++ b/test/weather_screen_test.dart
@@ -24,8 +24,14 @@ Future<ProviderContainer> _pumpMainAppWithMockNotifier(
     ],
   );
 
+  // 適切な画面サイズを設定してレイアウトオーバーフローを防ぐ
   tester.view.physicalSize = const Size(1200, 2400);
   tester.view.devicePixelRatio = 1.0;
+
+  addTearDown(() {
+    container.dispose();
+    tester.view.reset();
+  });
 
   // MainAppを起動
   await tester.pumpWidget(

--- a/test/weather_screen_test.dart
+++ b/test/weather_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_training/core/entity/weather_condition.dart';
 import 'package:flutter_training/main.dart';
 import 'package:flutter_training/ui/providers/weather_state_notifier_provider.dart';
 
+import 'extension/weather_condition_test_extension.dart';
 import 'mock/mock_weather_state_notifier.dart';
 
 Future<ProviderContainer> _pumpMainAppWithMockNotifier(
@@ -54,12 +55,7 @@ void main() {
 
     await tester.tap(find.text('Reload'));
     await tester.pumpAndSettle();
-    expect(
-      find.byWidgetPredicate(
-        (widget) => widget is SvgPicture && widget.semanticsLabel == 'sunny',
-      ),
-      findsOneWidget,
-    );
+    expect(WeatherCondition.sunny.finder, findsOneWidget);
     expect(find.byType(AlertDialog), findsNothing);
   });
 
@@ -72,12 +68,7 @@ void main() {
 
     await tester.tap(find.text('Reload'));
     await tester.pumpAndSettle();
-    expect(
-      find.byWidgetPredicate(
-        (widget) => widget is SvgPicture && widget.semanticsLabel == 'cloudy',
-      ),
-      findsOneWidget,
-    );
+    expect(WeatherCondition.cloudy.finder, findsOneWidget);
     expect(find.byType(AlertDialog), findsNothing);
   });
 
@@ -90,12 +81,7 @@ void main() {
 
     await tester.tap(find.text('Reload'));
     await tester.pumpAndSettle();
-    expect(
-      find.byWidgetPredicate(
-        (widget) => widget is SvgPicture && widget.semanticsLabel == 'rainy',
-      ),
-      findsOneWidget,
-    );
+    expect(WeatherCondition.rainy.finder, findsOneWidget);
     expect(find.byType(AlertDialog), findsNothing);
   });
 
@@ -103,13 +89,7 @@ void main() {
     await _pumpMainAppWithMockNotifier(tester);
     await tester.tap(find.text('Reload'));
     await tester.pumpAndSettle();
-    final maxTempFinder = find.byWidgetPredicate(
-      (widget) =>
-          widget is Text &&
-          widget.data == '30 ℃' &&
-          widget.style?.color == Colors.red,
-    );
-    expect(maxTempFinder, findsOneWidget);
+    expect(find.text('30 ℃'), findsOneWidget);
     expect(find.byType(AlertDialog), findsNothing);
   });
 
@@ -117,13 +97,7 @@ void main() {
     await _pumpMainAppWithMockNotifier(tester);
     await tester.tap(find.text('Reload'));
     await tester.pumpAndSettle();
-    final minTempFinder = find.byWidgetPredicate(
-      (widget) =>
-          widget is Text &&
-          widget.data == '20 ℃' &&
-          widget.style?.color == Colors.blue,
-    );
-    expect(minTempFinder, findsOneWidget);
+    expect(find.text('20 ℃'), findsOneWidget);
     expect(find.byType(AlertDialog), findsNothing);
   });
 


### PR DESCRIPTION
## 課題

close #11 

## 対応箇所
- widgetテストの実装
   - https://github.com/Ryosuke1025/flutter-training/pull/24 で、`APIClient`を差し替えて`Notifier`のテストを行ったため、今回は`Notifier`を差し替えて`Widget`テストを行った

## テスト内容

 - [x] 特定の条件で、天気予報画面に晴れの画像が表示されること
 - [x] 特定の条件で、天気予報画面に曇りの画像が表示されること
 - [x] 特定の条件で、天気予報画面に雨の画像が表示されること
 - [x] 特定の条件で、天気予報画面に最高気温が表示されること
 - [x] 特定の条件で、天気予報画面に最低気温が表示されること
 - [x] 特定の条件で、天気予報画面にダイアログが表示され、特定のメッセージが表示されること

## 動作
https://github.com/Ryosuke1025/flutter-training/pull/21 と変わらないので、省略

## 備考
- レビュー後に、エラーダイアログに関するテストと、`WeatherScreen`に関するテストを分けています